### PR TITLE
fix(ci): run astro via bun to avoid system Node.js version check

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,9 +21,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: '22'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - run: bun install
         working-directory: website

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - run: bun install
         working-directory: website

--- a/website/package.json
+++ b/website/package.json
@@ -2,9 +2,9 @@
   "name": "auto-pr-website",
   "private": true,
   "scripts": {
-    "dev": "bun run scripts/copy-docs.ts && astro dev",
-    "build": "bun run scripts/copy-docs.ts && astro build",
-    "preview": "astro preview"
+    "dev": "bun run scripts/copy-docs.ts && bun run node_modules/.bin/astro dev",
+    "build": "bun run scripts/copy-docs.ts && bun run node_modules/.bin/astro build",
+    "preview": "bun run node_modules/.bin/astro preview"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38.3",


### PR DESCRIPTION
## Summary

- `astro`'s binary has a `#!/usr/bin/env node` shebang, so invoking it as `astro build` in a shell script uses the system Node.js (v20 on `ubuntu-24.04`) rather than bun's runtime
- Astro requires `>=22.12.0` and fails with the system v20
- Fix: use `bun run node_modules/.bin/astro` in `package.json` scripts so bun intercepts execution — no `setup-node` step needed in the workflow

## Test plan

- [ ] Verify the `Deploy website` workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)