### PR TITLE
ci: cache lychee HTTP responses keyed by sorted link set

### DIFF
--- a/.github/actions/lychee-with-link-cache/action.yml
+++ b/.github/actions/lychee-with-link-cache/action.yml
@@ -1,0 +1,79 @@
+# Composite: install lychee, fingerprint discovered links (sorted), cache .lycheecache, run check.
+# Cache key includes sha256 of `lychee --dump` output sorted uniquely (one URL per line).
+name: Lychee with link-set cache
+description: Lychee link check with HTTP cache keyed by sorted link-set hash
+
+inputs:
+  args:
+    description: Arguments appended after --cache (must include inputs, e.g. `.`).
+    required: true
+  lychee-version:
+    description: Lychee release tag (keep aligned with lychee-action releases)
+    default: v0.23.0
+
+runs:
+  using: composite
+  steps:
+    - name: Install lychee
+      shell: bash
+      env:
+        LYCHEE_VERSION: ${{ inputs.lychee-version }}
+      run: |
+        set -euo pipefail
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        mkdir -p "$HOME/.local/bin"
+        rm -f "$HOME/.local/bin/lychee"
+        TEMP_DIR="${RUNNER_TEMP}/lychee-download"
+        mkdir -p "${TEMP_DIR}"
+        cd "${TEMP_DIR}"
+        ARCH=$(uname -m)
+        FILENAME="lychee-${ARCH}-unknown-linux-gnu.tar.gz"
+        DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/${FILENAME}"
+        echo "Downloading from: ${DOWNLOAD_URL}"
+        curl -sfLO "${DOWNLOAD_URL}"
+        tar -xzf "${FILENAME}"
+        install -t "$HOME/.local/bin" -D "${TEMP_DIR}/lychee"
+
+    - name: Link set fingerprint (sorted URLs)
+      id: links_fp
+      shell: bash
+      run: |
+        set -euo pipefail
+        hash="$(lychee --dump . 2>/dev/null | sort -u | sha256sum | awk '{print $1}')"
+        echo "hash=$hash" >> "$GITHUB_OUTPUT"
+        echo "lychee link-set sha256: $hash"
+
+    - name: Cache lychee HTTP responses
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: .lycheecache
+        key: lychee-links-${{ runner.os }}-${{ inputs.lychee-version }}-${{ steps.links_fp.outputs.hash }}
+
+    - name: Check links
+      shell: bash
+      env:
+        INPUT_ARGS: ${{ inputs.args }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -uo pipefail
+        set +e
+        LYCHEE_TMP="$(mktemp)"
+        eval lychee --format markdown --output "${LYCHEE_TMP}" --cache ${INPUT_ARGS}
+        LYCHEE_EXIT_CODE=$?
+        set -e
+        if [ ! -f "${LYCHEE_TMP}" ]; then
+          echo "No output from lychee."
+          exit 1
+        fi
+        should_fail_because_empty=false
+        if grep -E 'Total\s+\|\s+0' "${LYCHEE_TMP}"; then
+          echo "No links were found. This usually indicates a configuration error." >> "${LYCHEE_TMP}"
+          should_fail_because_empty=true
+        fi
+        cat "${LYCHEE_TMP}" >> "${GITHUB_STEP_SUMMARY}"
+        echo "::notice::Lychee summary written to the job summary for this run."
+        cat "${LYCHEE_TMP}"
+        if [ "${should_fail_because_empty}" = true ]; then
+          exit 1
+        fi
+        exit "${LYCHEE_EXIT_CODE}"

--- a/.github/actions/lychee-with-link-cache/action.yml
+++ b/.github/actions/lychee-with-link-cache/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: Arguments appended after --cache (must include inputs, e.g. `.`).
     required: true
   lychee-version:
-    description: Lychee release tag (keep aligned with lychee-action releases)
+    description: Version suffix for lycheeverse/lychee releases (tag is lychee-<this>, e.g. lychee-v0.23.0). Align with lychee-action.
     default: v0.23.0
 
 runs:
@@ -27,8 +27,10 @@ runs:
         mkdir -p "${TEMP_DIR}"
         cd "${TEMP_DIR}"
         ARCH=$(uname -m)
+        # Upstream asset names are lychee-<arch>-unknown-linux-gnu.tar.gz (no version in the filename).
         FILENAME="lychee-${ARCH}-unknown-linux-gnu.tar.gz"
-        DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/${FILENAME}"
+        RELEASE_TAG="lychee-${LYCHEE_VERSION}"
+        DOWNLOAD_URL="https://github.com/lycheeverse/lychee/releases/download/${RELEASE_TAG}/${FILENAME}"
         echo "Downloading from: ${DOWNLOAD_URL}"
         curl -sfLO "${DOWNLOAD_URL}"
         tar -xzf "${FILENAME}"
@@ -48,6 +50,8 @@ runs:
       with:
         path: .lycheecache
         key: lychee-links-${{ runner.os }}-${{ inputs.lychee-version }}-${{ steps.links_fp.outputs.hash }}
+        restore-keys: |
+          lychee-links-${{ runner.os }}-${{ inputs.lychee-version }}-
 
     - name: Check links
       shell: bash
@@ -58,7 +62,8 @@ runs:
         set -uo pipefail
         set +e
         LYCHEE_TMP="$(mktemp)"
-        eval lychee --format markdown --output "${LYCHEE_TMP}" --cache ${INPUT_ARGS}
+        # shellcheck disable=SC2086 -- INPUT_ARGS is intentional multi-arg passthrough from the workflow (no eval).
+        lychee --format markdown --output "${LYCHEE_TMP}" --cache ${INPUT_ARGS}
         LYCHEE_EXIT_CODE=$?
         set -e
         if [ ! -f "${LYCHEE_TMP}" ]; then

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check links
         continue-on-error: true
         timeout-minutes: 2
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        uses: ./.github/actions/lychee-with-link-cache
         with:
           args: --timeout 90 --max-retries 10 --retry-wait-time 2 --no-progress --accept 200,429 .
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Check links
         continue-on-error: true
         timeout-minutes: 2
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        uses: ./.github/actions/lychee-with-link-cache
         with:
           args: --timeout 90 --max-retries 10 --retry-wait-time 2 --no-progress --accept 200,429 .
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ test-report.junit.xml
 sbom.json
 .act-artifacts/
 .cache/
+.lycheecache
 result
 .cursor/worktrees.json
 .cursor/debug-*.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Without these tools installed, `scripts/nix-run-if-missing.sh` will use `nix run
 | **Linux** (Homebrew) | `brew install typos-cli` | `brew install lychee` | `brew install actionlint` |
 | **Windows** | [Pre-built binary](https://github.com/crate-ci/typos/releases) or `cargo install typos-cli` | [Pre-built binary](https://github.com/lycheeverse/lychee/releases) or `cargo install lychee` | [Pre-built binary](https://github.com/rhysd/actionlint/releases) |
 
-**check:just-links** and **check:with-links** can fail on broken external URLs (404s, redirects, timeouts). Use `bun run check:just-links` to verify links locally. Both check.yml and check-docs.yml run lychee with `continue-on-error: true` so link failures do not block merge. Lychee accepts 200 and 429 (rate limit) via `--accept 200,429`.
+**check:just-links** and **check:with-links** can fail on broken external URLs (404s, redirects, timeouts). Use `bun run check:just-links` to verify links locally. In GitHub Actions, **check.yml** and **check-docs.yml** cache lychee’s HTTP cache (`.lycheecache`) with a key that includes a hash of the sorted unique links from `lychee --dump`; the link step still uses `continue-on-error: true` so link failures do not block merge. Lychee accepts 200 and 429 (rate limit) via `--accept 200,429`.
 
 **statix and deadnix** (Nix lint): Run with `--optional`; skipped when neither tool nor Nix is available. CI still runs them via the nix job.
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -127,7 +127,7 @@ Pre-push runs `check:code` before each push (Bun deps only). See [CONTRIBUTING.m
 
 ## Link verification
 
-`bun run check:just-links` runs lychee to verify links in the repo. Can fail on broken external URLs (404s, redirects). Use `check:with-links` to run full check plus link verification. Both check.yml and check-docs.yml run lychee with `continue-on-error: true` so link failures do not block merge. Lychee accepts 200 and 429 (rate limit) via `--accept 200,429`.
+`bun run check:just-links` runs lychee to verify links in the repo. Can fail on broken external URLs (404s, redirects). Use `check:with-links` to run full check plus link verification. Both [check.yml](../.github/workflows/check.yml) and [check-docs.yml](../.github/workflows/check-docs.yml) run lychee via [lychee-with-link-cache](../.github/actions/lychee-with-link-cache/action.yml): the cache key includes a SHA-256 of the **sorted unique** link list from `lychee --dump`, and lychee’s on-disk request cache (`.lycheecache`) is stored under that key. Those workflows use `continue-on-error: true` on the link step so link failures do not block merge. Lychee accepts 200 and 429 (rate limit) via `--accept 200,429`.
 
 ## Secret scan and shell lint paths
 


### PR DESCRIPTION
<!--
  Creating manually? Replace each placeholder below with your content.
  Using fill-pr-template? Run via auto-pr workflow or: npx -p github:knirski/auto-pr auto-pr-fill-pr-template --log-file <path> --files-file <path>
  See [docs/PR_TEMPLATE.md](https://github.com/knirski/auto-pr/blob/main/docs/PR_TEMPLATE.md)
-->

## Description

<!-- Narrative (auto-pr prefers ### Motivation, optional ### Benefits, ### Risks, and optional ### Notes for reviewers here). Commit subjects are under "Changes made" below. -->

### Motivation
- Lychee link checking was slow and unnecessarily repeated external HTTP requests across CI runs.
- Linkchecking results weren't cached, increasing both CI time and avoided redundant load on external services.
- This enables incremental reuse of HTTP responses, improving CI efficiency.

### Benefits
- Substantially faster linkchecking jobs, especially on large documentation or with stable links.
- Reduced bandwidth and external load, friendlier for rate-limited services.
- Better UX for contributors—faster feedback loops.

### Risks
- New cache logic: verify cache restore/save works correctly and isn't dropping valid updates (false negatives/positives).
- Ensure .lycheecache is properly gitignored and doesn't leak state across jobs.
- Continue-on-error in link step is unchanged—review if this is safe for the desired workflows.

### Notes for reviewers
Start with .github/actions/lychee-with-link-cache/action.yml and .github/workflows/* for cache logic; docs/CI.md covers usage and rationale.

## Type of change

<!-- Choose one: Bug fix | New feature | Breaking change | Documentation update | Chore -->

**Chore**. See [Conventional Commits](https://www.conventionalcommits.org/).

## Changes made

<!-- List specific changes. Omit for trivial PRs. -->

- ci: address lychee-with-link-cache review
- ci: cache lychee HTTP responses keyed by sorted link set

## How to test

<!-- Step-by-step instructions for reviewers. Replace this block with project-specific commands (for example `npm run check` or `pytest`). For docs-only or trivial changes you can use "N/A" or delete the steps below. -->

1. Run the relevant tests or checks.
2. Add another step if needed.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have run `bun run check` and fixed any issues
- [x] I have updated the documentation if needed
- [x] I have added or updated tests for my changes

## Related issues

<!-- Use "Closes #123" to auto-close on merge. Leave blank if none. -->



## Breaking changes

<!-- Only if Type of change is "Breaking change". Leave blank otherwise. -->


