### PR TITLE
ci: remove duplicate bun nix ci dispatch

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,8 +4,6 @@
 # Uses GitHub App token for trusted same-repo update runs so the push can trigger CI
 # on the new commit (GITHUB_TOKEN pushes do not trigger workflows). Dependabot PRs
 # do not receive repository secrets, so they run bun.nix as check-only.
-# The `Trigger check on new commit` step below is retained — see its inline comment for why
-# an explicit `ci.yml` dispatch may still be needed after the App push.
 #
 # Uses upstream Nix (cachix/install-nix-action).
 # Builds on x86_64-linux, aarch64-linux, and aarch64-darwin (macos-latest).
@@ -87,21 +85,6 @@ jobs:
           git commit -m "fix(nix): update bun.nix for bun.lock"
           if ! git push; then
             echo "::error::git push failed (exit 128 often = permission denied; check App has Contents: Read and write)"
-            exit 1
-          fi
-
-      # Explicit `gh workflow run ci.yml` after the App-token push: branch protection
-      # needs checks on the new commit; PR synchronize may not always re-run consolidated
-      # CI on the pushed head. Re-evaluate before deleting (Area D Task 5 diagnostic).
-      - name: Trigger check on new commit
-        if: steps.bun-nix.outputs.changed == 'true' && inputs.push_allowed && github.actor != 'dependabot[bot]'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REF: ${{ inputs.ref || github.ref }}
-        run: |
-          BRANCH="${REF#refs/heads/}"
-          if ! gh workflow run ci.yml --ref "$BRANCH"; then
-            echo "::error::Failed to trigger ci.yml. Ensure App has Actions: Read and write permission."
             exit 1
           fi
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -69,7 +69,7 @@ The required PR **integration** job runs local llama scenarios only. The real **
 
 **auto-pr.yml** runs on push to `ai/**` branches (including forks). Two reusable workflows: generate (unprivileged checkout + content) and create (trusted checkout + PR). The generate job uses composite actions from this repo; adopters do not vendor shell under `scripts/`. Security model: [docs/WORKFLOW_SECURITY.md](WORKFLOW_SECURITY.md). Forks need `APP_ID` and `APP_PRIVATE_KEY` in their repo secrets to succeed. See [docs/INTEGRATION.md](INTEGRATION.md).
 
-**ci.yml** is the single entry for push/PR to `main`: the `changes` job applies path filters so each downstream job runs only when relevant. The **`gate`** job aggregates outcomes for branch protection as **`CI / gate`**. The **`nix`** job calls [nix.yml](../.github/workflows/nix.yml): upstream Nix ([cachix/install-nix-action](https://github.com/cachix/install-nix-action)), statix/deadnix via `nix flake check`, and auto-updates `bun.nix` for trusted same-repo runs using the same GitHub App as auto-pr when a push is needed (GITHUB_TOKEN pushes do not trigger workflows). Dependabot PRs are check-only because GitHub does not expose repository secrets to Dependabot-triggered runs.
+**ci.yml** is the single entry for push/PR to `main`: the `changes` job applies path filters so each downstream job runs only when relevant. The **`gate`** job aggregates outcomes for branch protection as **`CI / gate`**. The **`nix`** job calls [nix.yml](../.github/workflows/nix.yml): upstream Nix ([cachix/install-nix-action](https://github.com/cachix/install-nix-action)), statix/deadnix via `nix flake check`, and auto-updates `bun.nix` for trusted same-repo runs using the same GitHub App as auto-pr when a push is needed (GITHUB_TOKEN pushes do not trigger workflows). The App-token push naturally triggers the PR's next `pull_request` CI run on the generated commit; do not manually dispatch `ci.yml` after the push, because that creates an extra `workflow_dispatch` run that is not part of the PR check rollup. Dependabot PRs are check-only because GitHub does not expose repository secrets to Dependabot-triggered runs.
 
 **sbom.yml** runs nightly and on manual trigger. It generates and uploads a CycloneDX SBOM with npm's native `sbom` command outside the required PR gate. This keeps npm peer-resolution differences from blocking Bun dependency PRs while preserving regular SBOM artifacts.
 
@@ -147,7 +147,7 @@ Do NOT require individual job names (`check / check`, `dependency-review`, etc.)
 
 When the **`nix`** job pushes a `bun.nix` update, the PR head changes to a new commit. **`CI / gate`** must run on that new commit. If you see "waiting for status to be reported":
 
-1. **Wait 1–2 minutes** — The push triggers the check workflow; it may take a moment to start.
+1. **Wait 1–2 minutes** — The App-token push triggers the PR check workflow; it may take a moment to start.
 2. **Re-run workflows** — If the check still hasn't run, use "Re-run all jobs" from the Actions tab.
 3. **Manual trigger** — Push an empty commit: `git commit --allow-empty -m "ci: trigger workflows" && git push`.
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -69,7 +69,7 @@ The required PR **integration** job runs local llama scenarios only. The real **
 
 **auto-pr.yml** runs on push to `ai/**` branches (including forks). Two reusable workflows: generate (unprivileged checkout + content) and create (trusted checkout + PR). The generate job uses composite actions from this repo; adopters do not vendor shell under `scripts/`. Security model: [docs/WORKFLOW_SECURITY.md](WORKFLOW_SECURITY.md). Forks need `APP_ID` and `APP_PRIVATE_KEY` in their repo secrets to succeed. See [docs/INTEGRATION.md](INTEGRATION.md).
 
-**ci.yml** is the single entry for push/PR to `main`: the `changes` job applies path filters so each downstream job runs only when relevant. The **`gate`** job aggregates outcomes for branch protection as **`CI / gate`**. The **`nix`** job calls [nix.yml](../.github/workflows/nix.yml): upstream Nix ([cachix/install-nix-action](https://github.com/cachix/install-nix-action)), statix/deadnix via `nix flake check`, and auto-updates `bun.nix` for trusted same-repo runs using the same GitHub App as auto-pr when a push is needed (GITHUB_TOKEN pushes do not trigger workflows). The App-token push naturally triggers the PR's next `pull_request` CI run on the generated commit; do not manually dispatch `ci.yml` after the push, because that creates an extra `workflow_dispatch` run that is not part of the PR check rollup. Dependabot PRs are check-only because GitHub does not expose repository secrets to Dependabot-triggered runs.
+**ci.yml** is the single entry for push/PR to `main`: the `changes` job applies path filters so each downstream job runs only when relevant. The **`gate`** job aggregates outcomes for branch protection as **`CI / gate`**. The **`nix`** job calls [nix.yml](../.github/workflows/nix.yml): upstream Nix ([cachix/install-nix-action](https://github.com/cachix/install-nix-action)), statix/deadnix via `nix flake check`, and auto-updates `bun.nix` for trusted same-repo runs using the same GitHub App as auto-pr when a push is needed (GITHUB_TOKEN pushes do not trigger workflows). The GitHub App token push naturally triggers a new `pull_request` CI run on the generated commit; do not manually dispatch `ci.yml` after the push, because that creates an extra `workflow_dispatch` run that is not part of the PR check rollup. Dependabot PRs are check-only because GitHub does not expose repository secrets to Dependabot-triggered runs.
 
 **sbom.yml** runs nightly and on manual trigger. It generates and uploads a CycloneDX SBOM with npm's native `sbom` command outside the required PR gate. This keeps npm peer-resolution differences from blocking Bun dependency PRs while preserving regular SBOM artifacts.
 
@@ -147,7 +147,7 @@ Do NOT require individual job names (`check / check`, `dependency-review`, etc.)
 
 When the **`nix`** job pushes a `bun.nix` update, the PR head changes to a new commit. **`CI / gate`** must run on that new commit. If you see "waiting for status to be reported":
 
-1. **Wait 1–2 minutes** — The App-token push triggers the PR check workflow; it may take a moment to start.
+1. **Wait 1–2 minutes** — The GitHub App token push triggers the PR check workflow; it may take a moment to start.
 2. **Re-run workflows** — If the check still hasn't run, use "Re-run all jobs" from the Actions tab.
 3. **Manual trigger** — Push an empty commit: `git commit --allow-empty -m "ci: trigger workflows" && git push`.
 


### PR DESCRIPTION
<!--
  Creating manually? Replace each placeholder below with your content.
  Using fill-pr-template? Run via auto-pr workflow or: npx -p github:knirski/auto-pr auto-pr-fill-pr-template --log-file <path> --files-file <path>
  See [docs/PR_TEMPLATE.md](https://github.com/knirski/auto-pr/blob/main/docs/PR_TEMPLATE.md)
-->

## Description

<!-- Narrative (auto-pr prefers ### Motivation, optional ### Benefits, ### Risks, and optional ### Notes for reviewers here). Commit subjects are under "Changes made" below. -->

### Motivation
- GitHub Actions workflow `.github/workflows/nix.yml` contained redundant dispatch logic for Bun and Nix, leading to unnecessary complexity and maintenance overhead.
- Clarifies how CI triggers work with app tokens versus PATs in `docs/CI.md`.

### Benefits
- Simplified workflow reduces confusion and maintenance burden.
- Documentation is clearer for CI triggers.

### Risks
- Low risk: workflow-only and doc changes. Confirm nothing important is lost from removed `.github/workflows/nix.yml` steps.
- Ensure no essential Bun logic is missing after removal.

### Notes for reviewers
No need to review code outside `.github/workflows/nix.yml` and `docs/CI.md`.

## Type of change

<!-- Choose one: Bug fix | New feature | Breaking change | Documentation update | Chore -->

**Chore**. See [Conventional Commits](https://www.conventionalcommits.org/).

## Changes made

<!-- List specific changes. Omit for trivial PRs. -->

- docs: clarify app token ci trigger
- ci: remove duplicate bun nix ci dispatch

## How to test

<!-- Step-by-step instructions for reviewers. Replace this block with project-specific commands (for example `npm run check` or `pytest`). For docs-only or trivial changes you can use "N/A" or delete the steps below. -->

1. Run the relevant tests or checks.
2. Add another step if needed.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have run `bun run check` and fixed any issues
- [x] I have updated the documentation if needed
- [ ] I have added or updated tests for my changes

## Related issues

<!-- Use "Closes #123" to auto-close on merge. Leave blank if none. -->



## Breaking changes

<!-- Only if Type of change is "Breaking change". Leave blank otherwise. -->


