### PR TITLE
fix: jitter retry schedules

### DIFF
--- a/src/workflow/auto-pr-create-or-update-pr.ts
+++ b/src/workflow/auto-pr-create-or-update-pr.ts
@@ -141,6 +141,7 @@ function createGhRetrySchedule(
 				message: `gh failed, retrying in about ${delayLabel}...`,
 			}).pipe(Effect.as(delay)),
 		),
+		// Effect v4 jitter keeps the delay within 80%-120%, so the log remains approximate.
 		Schedule.jittered,
 	);
 }

--- a/src/workflow/auto-pr-create-or-update-pr.ts
+++ b/src/workflow/auto-pr-create-or-update-pr.ts
@@ -129,9 +129,10 @@ function createGhRetrySchedule(branch: string) {
 				event: "create_or_update_pr",
 				status: "gh_retry",
 				branch,
-				message: "gh failed, retrying in 5s...",
+				message: "gh failed, retrying in about 5s...",
 			}).pipe(Effect.as(Duration.millis(GH_RETRY_DELAY_MS))),
 		),
+		Schedule.jittered,
 	);
 }
 

--- a/src/workflow/auto-pr-create-or-update-pr.ts
+++ b/src/workflow/auto-pr-create-or-update-pr.ts
@@ -122,15 +122,24 @@ function ghPrCreate(
 	);
 }
 
-function createGhRetrySchedule(branch: string) {
+function formatRetryDelay(delay: Duration.Duration): string {
+	const delayMs = Duration.toMillis(delay);
+	return delayMs >= 1000 ? `${delayMs / 1000}s` : `${delayMs}ms`;
+}
+
+function createGhRetrySchedule(
+	branch: string,
+	delay: Duration.Duration = Duration.millis(GH_RETRY_DELAY_MS),
+) {
+	const delayLabel = formatRetryDelay(delay);
 	return Schedule.recurs(GH_RETRY_ATTEMPTS - 1).pipe(
 		Schedule.addDelay(() =>
 			Effect.logWarning({
 				event: "create_or_update_pr",
 				status: "gh_retry",
 				branch,
-				message: "gh failed, retrying in about 5s...",
-			}).pipe(Effect.as(Duration.millis(GH_RETRY_DELAY_MS))),
+				message: `gh failed, retrying in about ${delayLabel}...`,
+			}).pipe(Effect.as(delay)),
 		),
 		Schedule.jittered,
 	);
@@ -139,9 +148,10 @@ function createGhRetrySchedule(branch: string) {
 function runGhWithRetry<R, E, A>(
 	effect: Effect.Effect<A, E, R>,
 	branch: string,
+	retryDelay?: Duration.Duration,
 ): Effect.Effect<A, E, R> {
 	return effect.pipe(
-		Effect.retry(createGhRetrySchedule(branch)),
+		Effect.retry(createGhRetrySchedule(branch, retryDelay)),
 		Effect.tapError(() =>
 			Effect.logError({
 				event: "create_or_update_pr",
@@ -167,6 +177,7 @@ export function runCreateOrUpdatePr(params: {
 	title: string;
 	bodyFile: string;
 	workspace: string;
+	retryDelay?: Duration.Duration;
 }): Effect.Effect<void, CreateOrUpdatePrError, ChildProcessSpawner | FileSystem.FileSystem> {
 	return Effect.gen(function* () {
 		const fs = yield* FileSystem.FileSystem;
@@ -190,7 +201,11 @@ export function runCreateOrUpdatePr(params: {
 				prNumber,
 				titlePreview: params.title.slice(0, 50),
 			});
-			yield* runGhWithRetry(ghPrEdit(prNumber, params.title, params.bodyFile, cwd), params.branch);
+			yield* runGhWithRetry(
+				ghPrEdit(prNumber, params.title, params.bodyFile, cwd),
+				params.branch,
+				params.retryDelay,
+			);
 			yield* Effect.log({
 				event: "create_or_update_pr",
 				status: "updated",
@@ -208,6 +223,7 @@ export function runCreateOrUpdatePr(params: {
 			const stdout = yield* runGhWithRetry(
 				ghPrCreate(params.branch, params.defaultBranch, params.title, params.bodyFile, cwd),
 				params.branch,
+				params.retryDelay,
 			);
 			const url = yield* Effect.fromResult(parseGhPrCreateOutput(stdout));
 			yield* Effect.log({

--- a/src/workflow/auto-pr-generate-content.ts
+++ b/src/workflow/auto-pr-generate-content.ts
@@ -278,9 +278,10 @@ function makeRetrySchedule(delay: Duration.Duration) {
 			Effect.logWarning({
 				event: "generate_pr_content",
 				status: "ai_retry",
-				message: `Title invalid or AI failed, retrying in ${delayLabel}...`,
+				message: `Title invalid or AI failed, retrying in about ${delayLabel}...`,
 			}).pipe(Effect.as(delay)),
 		),
+		Schedule.jittered,
 	);
 }
 

--- a/src/workflow/auto-pr-generate-content.ts
+++ b/src/workflow/auto-pr-generate-content.ts
@@ -281,6 +281,7 @@ function makeRetrySchedule(delay: Duration.Duration) {
 				message: `Title invalid or AI failed, retrying in about ${delayLabel}...`,
 			}).pipe(Effect.as(delay)),
 		),
+		// Effect v4 jitter keeps the delay within 80%-120%, so the log remains approximate.
 		Schedule.jittered,
 	);
 }

--- a/test/workflow/create-or-update-pr.test.ts
+++ b/test/workflow/create-or-update-pr.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { Cause, Effect, Exit, Layer, Option, Result, Stream } from "effect";
+import { Cause, Duration, Effect, Exit, Layer, Option, Result, Stream } from "effect";
 import { systemError } from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
 import { PrLookupError } from "#core/errors.js";
@@ -52,6 +52,61 @@ describe("runCreateOrUpdatePr", () => {
 					bodyFile: bodyPath,
 					workspace: tmp.path,
 				});
+			}).pipe(Effect.scoped),
+		);
+	});
+
+	test("retries gh create after transient failure", async () => {
+		let createCalls = 0;
+		const mock = Layer.mock(ChildProcessSpawner)({
+			string: (cmd: { _tag: string; command?: string; args?: readonly string[] }) => {
+				const args = "args" in cmd ? cmd.args : [];
+				if (cmd.command === "gh" && args[1] === "view") {
+					return Effect.fail(
+						systemError({
+							_tag: "NotFound",
+							module: "gh",
+							method: "pr view",
+							description: "no PR found",
+						}),
+					);
+				}
+				if (cmd.command === "gh" && args[1] === "create") {
+					createCalls += 1;
+					if (createCalls === 1) {
+						return Effect.fail(
+							systemError({
+								_tag: "Unknown",
+								module: "gh",
+								method: "pr create",
+								description: "temporary gh failure",
+							}),
+						);
+					}
+					return Effect.succeed("https://github.com/owner/repo/pull/99\n");
+				}
+				return Effect.succeed("");
+			},
+			streamString: () => Stream.empty,
+			streamLines: () => Stream.empty,
+		});
+
+		await runEffect(Layer.mergeAll(TestBaseLayer, SilentLoggerLayer, mock))(
+			Effect.gen(function* () {
+				const tmp = yield* createTestTempDirEffect("create-pr-retry-");
+				const bodyPath = tmp.join("pr-body.md");
+				yield* tmp.writeFile(bodyPath, "# PR body\n\nNew feature description.");
+
+				yield* runCreateOrUpdatePr({
+					branch: "ai/retry",
+					defaultBranch: "main",
+					title: "feat: add retry",
+					bodyFile: bodyPath,
+					workspace: tmp.path,
+					retryDelay: Duration.zero,
+				});
+
+				expect(createCalls).toBe(2);
 			}).pipe(Effect.scoped),
 		);
 	});


### PR DESCRIPTION
<!--
  Creating manually? Replace each placeholder below with your content.
  Using fill-pr-template? Run via auto-pr workflow or: npx -p github:knirski/auto-pr auto-pr-fill-pr-template --log-file <path> --files-file <path>
  See [docs/PR_TEMPLATE.md](https://github.com/knirski/auto-pr/blob/main/docs/PR_TEMPLATE.md)
-->

## Description

<!-- Narrative (auto-pr prefers ### Motivation, optional ### Benefits, ### Risks, and optional ### Notes for reviewers here). Commit subjects are under "Changes made" below. -->

### Motivation
- Retry schedules were not correctly jittered, potentially causing synchronized failures or insufficient randomness in retry timing.
- The branch aims to document, implement, and test a bounded retry jitter mechanism, improving resilience against transient errors in GitHub API interactions.

### Benefits
- More robust retry logic reduces the risk of synchronized failures and API rate limiting.
- Clear documentation and tests improve maintainability and confidence in further changes.

### Risks
- Ensure the jitter calculation is bounded and does not introduce excessive delay.
- Test coverage for retry logic must accurately simulate failure and recovery scenarios.
- Risk is contained to retry behavior in GitHub interaction code paths.

### Notes for reviewers
Start with src/workflow/auto-pr-create-or-update-pr.ts for implementation and test/workflow/create-or-update-pr.test.ts for test coverage. Review changes in src/workflow/auto-pr-generate-content.ts if relevant to retry handling.

## Type of change

<!-- Choose one: Bug fix | New feature | Breaking change | Documentation update | Chore -->

**Bug fix**. See [Conventional Commits](https://www.conventionalcommits.org/).

## Changes made

<!-- List specific changes. Omit for trivial PRs. -->

- fix: document bounded retry jitter
- test: cover gh retry path
- fix: jitter retry schedules

## How to test

<!-- Step-by-step instructions for reviewers. Replace this block with project-specific commands (for example `npm run check` or `pytest`). For docs-only or trivial changes you can use "N/A" or delete the steps below. -->

1. Run the relevant tests or checks.
2. Add another step if needed.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have run `bun run check` and fixed any issues
- [ ] I have updated the documentation if needed
- [x] I have added or updated tests for my changes

## Related issues

<!-- Use "Closes #123" to auto-close on merge. Leave blank if none. -->



## Breaking changes

<!-- Only if Type of change is "Breaking change". Leave blank otherwise. -->


