### PR TITLE
docs: clarify website publishing and provider defaults

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -233,6 +233,17 @@ For branches with **2+ commits**, auto-pr generates the PR description via an AI
 
 **How it calls the model:** The generate step uses **`LanguageModel.generateText`** with a prompt that asks for JSON (`title`, `motivation`, `benefits`, `risks`, `notesForReviewers`). It parses the assistant reply and validates with Effect Schema — not OpenAI **`generateObject`** / **`json_schema`**, because GitHub Models does not support that response format and other OpenAI-compatible servers are inconsistent with it. On repeated parse or transient HTTP failures (network, rate limit, 5xx), auto-pr falls back to commit-derived title and description. **Authentication errors (HTTP 401/403) surface directly as a configuration error** rather than silently falling back — check your `GH_TOKEN` or `AUTO_PR_AI_OPENAI_COMPAT_API_KEY` if you see an auth error in the generate step.
 
+### Provider defaults
+
+Defaults differ by entry point so local development can run against a local OpenAI-compatible server, while the stock GitHub workflow works without hosting a model yourself.
+
+| Entry point | Provider default | Model default | Notes |
+|-------------|------------------|---------------|-------|
+| Stock [`auto-pr.yml`](../.github/workflows/auto-pr.yml) | `github-models` | `openai/gpt-4.1` | The workflow grants `models: read` and passes `github.token` to the generate reusable workflow. |
+| Generate reusable workflow with `ai_provider: local` and `ai_llamacpp_model_url` | `local` | `gpt-oss` unless `ai_openai_compat_model` is set | Starts `llama-server` in Docker and uses the local OpenAI-compatible endpoint. |
+| Local CLI / `bun run generate-content` with no AI env | `local` | `gpt-oss` | Targets `http://127.0.0.1:8080/v1`. |
+| Local CLI / custom workflow with `AUTO_PR_AI_PROVIDER=github-models` and no model env | `github-models` | `microsoft/phi-4-mini-instruct` | Export `GH_TOKEN`; override `AUTO_PR_AI_OPENAI_COMPAT_MODEL` when you want another GitHub Models id. |
+
 ### `local` (OpenAI-compatible HTTP)
 
 Any OpenAI-compatible endpoint (llama.cpp `llama-server`, remote gateways, etc.) using the same env names as in [`src/auto-pr/config.ts`](../src/auto-pr/config.ts): `AUTO_PR_AI_OPENAI_COMPAT_URL`, optional `AUTO_PR_AI_OPENAI_COMPAT_API_KEY`, and `AUTO_PR_AI_OPENAI_COMPAT_MODEL`.
@@ -302,4 +313,4 @@ If you work on **this** repository (not only consuming the workflow), `bun run t
 | "Resource not accessible" | Check app permissions (Contents, Pull requests, Actions: Read and write) |
 | "Secret not found" | Verify `APP_ID` and `APP_PRIVATE_KEY` in repo secrets |
 | PR already exists | Workflow updates the PR title and body from the latest commits |
-| AI provider returns invalid description | Retries 3×; description override may be empty on failure |
+| AI provider returns invalid description | Retries up to five attempts; description override may be empty on failure |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 ## Structure
 
+User-facing and contributor docs live at the top of `docs/` and are published to the website. ADRs under `docs/adr/` are also published, but historical supporting research and implementation plans remain repository-only unless a published page links to the GitHub source.
+
 | Audience | Document | Purpose |
 |----------|----------|---------|
 | **Users (adopters)** | [INTEGRATION.md](INTEGRATION.md) | Add auto-pr to a repo — setup, GitHub App, workflow |
@@ -14,6 +16,12 @@
 | | [CII.md](CII.md) | OpenSSF Best Practices badge progress |
 | | [CONTRIBUTING.md](../CONTRIBUTING.md) | Development setup, commits, PRs |
 | **Decisions** | [adr/](adr/) | Architecture Decision Records and supporting research |
+
+## Publishing model
+
+- Published to the documentation website: top-level `docs/*.md` except this index, plus top-level ADRs in `docs/adr/`.
+- Linked as GitHub source from the website: workflow/action files, root files such as `CONTRIBUTING.md`, ADR supporting research, and `docs/superpowers/` design artifacts.
+- Canonical operational references: [INTEGRATION.md](INTEGRATION.md) for adopters, [CI.md](CI.md) for workflow behavior, [ARCHITECTURE.md](ARCHITECTURE.md) for code structure.
 
 ## Quick links
 

--- a/test/website/copy-docs.test.ts
+++ b/test/website/copy-docs.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { rewriteLinks } from "../../website/scripts/copy-docs-core.js";
+
+describe("website copy-docs link rewriting", () => {
+	test("rewrites published top-level docs to site routes", () => {
+		const input = "See [CI](CI.md#workflow-pin-automation).";
+
+		expect(rewriteLinks(input, "docs")).toBe("See [CI](/auto-pr/ci/#workflow-pin-automation).");
+	});
+
+	test("rewrites published ADRs to site routes", () => {
+		const input = "See [ADR](0007-ai-abstraction-layer.md).";
+
+		expect(rewriteLinks(input, "docs/adr")).toBe(
+			"See [ADR](/auto-pr/adr/0007-ai-abstraction-layer/).",
+		);
+	});
+
+	test("rewrites repository-only markdown links to GitHub source", () => {
+		const input =
+			"See [supporting research](supporting/nix-ci-research.md) and [contributing](../../CONTRIBUTING.md).";
+
+		expect(rewriteLinks(input, "docs/adr")).toBe(
+			"See [supporting research](https://github.com/knirski/auto-pr/blob/main/docs/adr/supporting/nix-ci-research.md) and [contributing](https://github.com/knirski/auto-pr/blob/main/CONTRIBUTING.md).",
+		);
+	});
+
+	test("rewrites workflow and action links to GitHub source", () => {
+		const input =
+			"Copy [workflow](../.github/workflows/auto-pr.yml) or read [setup-runtime](../.github/actions/setup-runtime/README.md).";
+
+		expect(rewriteLinks(input, "docs")).toBe(
+			"Copy [workflow](https://github.com/knirski/auto-pr/blob/main/.github/workflows/auto-pr.yml) or read [setup-runtime](https://github.com/knirski/auto-pr/blob/main/.github/actions/setup-runtime/README.md).",
+		);
+	});
+
+	test("leaves external and anchor links unchanged", () => {
+		const input = "See [GitHub](https://github.com/knirski/auto-pr) and [section](#setup).";
+
+		expect(rewriteLinks(input, "docs")).toBe(input);
+	});
+});

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,7 @@
 {
   "name": "auto-pr-website",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "bun run scripts/copy-docs.ts && bun run node_modules/.bin/astro dev",
     "build": "bun run scripts/copy-docs.ts && bun run node_modules/.bin/astro build",

--- a/website/scripts/copy-docs-core.ts
+++ b/website/scripts/copy-docs-core.ts
@@ -1,0 +1,66 @@
+import { posix } from "node:path";
+
+const SITE_BASE = "/auto-pr/";
+const REPO_BLOB_BASE = "https://github.com/knirski/auto-pr/blob/main/";
+const EXCLUDED_FILES = new Set(["README.md"]);
+const EXCLUDED_ADR_FILES = new Set(["adr-template.md"]);
+
+function isExternalHref(href: string): boolean {
+	return /^(?:[a-z][a-z0-9+.-]*:|#)/i.test(href);
+}
+
+function splitHref(href: string): readonly [path: string, anchor: string] {
+	const [path = "", anchor = ""] = href.split("#", 2);
+	return [path, anchor];
+}
+
+function normalizeRepoPath(sourceDir: string, hrefPath: string): string {
+	const rawPath = hrefPath.startsWith("/") ? hrefPath.slice(1) : posix.join(sourceDir, hrefPath);
+	return posix.normalize(rawPath);
+}
+
+function routeForPublishedMarkdown(repoPath: string): string | undefined {
+	if (repoPath.startsWith("docs/adr/")) {
+		const file = repoPath.slice("docs/adr/".length);
+		if (!file.endsWith(".md") || file.includes("/") || EXCLUDED_ADR_FILES.has(file)) {
+			return undefined;
+		}
+		return file === "README.md"
+			? `${SITE_BASE}adr/`
+			: `${SITE_BASE}adr/${file.replace(/\.md$/, "").toLowerCase()}/`;
+	}
+
+	if (repoPath.startsWith("docs/")) {
+		const file = repoPath.slice("docs/".length);
+		if (!file.endsWith(".md") || file.includes("/") || EXCLUDED_FILES.has(file)) {
+			return undefined;
+		}
+		const slug = file.replace(/\.md$/, "").toLowerCase().replace(/_/g, "-");
+		return `${SITE_BASE}${slug}/`;
+	}
+
+	return undefined;
+}
+
+function hrefForRepoPath(repoPath: string, anchor: string): string {
+	const anchorSuffix = anchor ? `#${anchor}` : "";
+	const siteRoute = routeForPublishedMarkdown(repoPath);
+	if (siteRoute) {
+		return `${siteRoute}${anchorSuffix}`;
+	}
+
+	return `${REPO_BLOB_BASE}${repoPath}${anchorSuffix}`;
+}
+
+export function rewriteLinks(content: string, sourceDir: string): string {
+	return content.replace(/\]\(([^)]+)\)/g, (full, href: string) => {
+		if (isExternalHref(href)) {
+			return full;
+		}
+
+		const [hrefPath, anchor] = splitHref(href);
+		if (!hrefPath) return full;
+		const repoPath = normalizeRepoPath(sourceDir, hrefPath);
+		return `](${hrefForRepoPath(repoPath, anchor)})`;
+	});
+}

--- a/website/scripts/copy-docs.ts
+++ b/website/scripts/copy-docs.ts
@@ -1,5 +1,7 @@
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, posix } from "node:path";
+
+import { rewriteLinks } from "./copy-docs-core.js";
 
 const REPO_ROOT = join(import.meta.dirname, "..", "..");
 const DOCS_DIR = join(REPO_ROOT, "docs");
@@ -21,30 +23,11 @@ const docsMeta: Record<string, DocMeta> = {
 };
 
 const EXCLUDED_FILES = new Set(["README.md"]);
+const EXCLUDED_ADR_FILES = new Set(["adr-template.md"]);
 
 function extractTitle(content: string): string {
 	const match = content.match(/^#\s+(.+)$/m);
-	return match ? match[1].trim() : "Untitled";
-}
-
-function rewriteLinks(content: string, subdir: string = ""): string {
-	return content.replace(/\]\(([^)]+)\)/g, (full, href: string) => {
-		if (href.startsWith("http") || href.startsWith("#") || href.startsWith("../")) {
-			return full;
-		}
-
-		const [filePart, anchor] = href.split("#");
-		if (!filePart?.endsWith(".md")) {
-			return full;
-		}
-
-		const slug = filePart.replace(/\.md$/, "").toLowerCase().replace(/_/g, "-");
-
-		// For relative links (no directory component), prepend the subdir
-		const prefix = filePart.includes("/") ? "" : subdir;
-		const anchorSuffix = anchor ? `#${anchor}` : "";
-		return `](/auto-pr/${prefix}${slug}/${anchorSuffix})`;
-	});
+	return match?.[1]?.trim() ?? "Untitled";
 }
 
 function buildFrontmatter(title: string, meta?: DocMeta, editUrl?: string): string {
@@ -72,7 +55,6 @@ async function processFile(
 	srcPath: string,
 	destPath: string,
 	meta?: DocMeta,
-	subdir: string = "",
 	repoRelativePath?: string,
 ): Promise<void> {
 	const raw = await readFile(srcPath, "utf-8");
@@ -81,7 +63,8 @@ async function processFile(
 		? `https://github.com/knirski/auto-pr/edit/main/${repoRelativePath}`
 		: undefined;
 	const frontmatter = buildFrontmatter(title, meta, editUrl);
-	const rewritten = rewriteLinks(stripH1(raw), subdir);
+	const sourceDir = repoRelativePath ? posix.dirname(repoRelativePath) : "docs";
+	const rewritten = rewriteLinks(stripH1(raw), sourceDir);
 	await mkdir(dirname(destPath), { recursive: true });
 	await writeFile(destPath, frontmatter + rewritten);
 }
@@ -104,7 +87,6 @@ async function main(): Promise<void> {
 			join(DOCS_DIR, file),
 			join(OUTPUT_DIR, destName),
 			docsMeta[file],
-			"",
 			`docs/${file}`,
 		);
 	}
@@ -114,23 +96,24 @@ async function main(): Promise<void> {
 	const adrFiles = await readdir(adrDir);
 	for (const file of adrFiles) {
 		if (!file.endsWith(".md")) continue;
-		if (file === "adr-template.md") continue;
+		if (EXCLUDED_ADR_FILES.has(file)) continue;
 		const destName = file === "README.md" ? "index.md" : file.toLowerCase();
 		await processFile(
 			join(adrDir, file),
 			join(OUTPUT_DIR, "adr", destName),
 			undefined,
-			"adr/",
 			`docs/adr/${file}`,
 		);
 	}
 
 	const topCount = topLevel.filter((f) => f.endsWith(".md") && !EXCLUDED_FILES.has(f)).length;
-	const adrCount = adrFiles.filter((f) => f.endsWith(".md") && f !== "adr-template.md").length;
+	const adrCount = adrFiles.filter((f) => f.endsWith(".md") && !EXCLUDED_ADR_FILES.has(f)).length;
 	process.stdout.write(`Copied ${topCount} docs + ${adrCount} ADRs → ${OUTPUT_DIR}\n`);
 }
 
-main().catch((err) => {
-	process.stderr.write(`${String(err)}\n`);
-	process.exit(1);
-});
+if (import.meta.main) {
+	main().catch((err) => {
+		process.stderr.write(`${String(err)}\n`);
+		process.exit(1);
+	});
+}


### PR DESCRIPTION
<!--
  Creating manually? Replace each placeholder below with your content.
  Using fill-pr-template? Run via auto-pr workflow or: npx -p github:knirski/auto-pr auto-pr-fill-pr-template --log-file <path> --files-file <path>
  See [docs/PR_TEMPLATE.md](https://github.com/knirski/auto-pr/blob/main/docs/PR_TEMPLATE.md)
-->

## Description

<!-- Narrative (auto-pr prefers ### Motivation, optional ### Benefits, ### Risks, and optional ### Notes for reviewers here). Commit subjects are under "Changes made" below. -->

clarify website publishing and provider defaults

## Type of change

<!-- Choose one: Bug fix | New feature | Breaking change | Documentation update | Chore -->

**Documentation update**. See [Conventional Commits](https://www.conventionalcommits.org/).

## Changes made

<!-- List specific changes. Omit for trivial PRs. -->

- docs: clarify website publishing and provider defaults

## How to test

<!-- Step-by-step instructions for reviewers. Replace this block with project-specific commands (for example `npm run check` or `pytest`). For docs-only or trivial changes you can use "N/A" or delete the steps below. -->

1. Run the relevant tests or checks.
2. Add another step if needed.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have run `bun run check` and fixed any issues
- [x] I have updated the documentation if needed
- [x] I have added or updated tests for my changes

## Related issues

<!-- Use "Closes #123" to auto-close on merge. Leave blank if none. -->



## Breaking changes

<!-- Only if Type of change is "Breaking change". Leave blank otherwise. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added provider defaults section detailing entry-point-specific AI provider and model selection configurations.
  * Updated troubleshooting guidance: invalid AI descriptions now trigger up to five retry attempts before proceeding.
  * Established documentation publishing model clarifying which content is published, sourced as GitHub references, and retained as operational references.

* **Tests**
  * Introduced comprehensive test suite for markdown link rewriting, covering published docs, ADRs, repository links, and external URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->