### PR TITLE
refactor(test): deduplicate llama HTTP guards and improve diagnostics

### DIFF
--- a/test/integration/llama-local-container.ts
+++ b/test/integration/llama-local-container.ts
@@ -229,6 +229,22 @@ function openAiModelsListUrl(openAiCompatBase: URL): URL {
 	return new URL("models", base);
 }
 
+const failOnNonSuccessStatus = Effect.fn("failOnNonSuccessStatus")(function* (options: {
+	readonly response: { readonly status: number };
+	readonly operation: string;
+	readonly requestUrl: URL;
+}) {
+	const { response, operation, requestUrl } = options;
+	if (response.status < 200 || response.status >= 300) {
+		return yield* Effect.fail(
+			new LlamaIntegrationHttpError({
+				operation: `${operation}: unexpected HTTP status ${response.status} from ${requestUrl.href}`,
+				cause: response,
+			}),
+		);
+	}
+});
+
 const readPinnedImageFromDockerfile = Effect.fn("readPinnedImageFromDockerfile")(function* () {
 	const integrationTestDir = yield* integrationTestDirectory();
 	const p = yield* Path.Path;
@@ -320,14 +336,11 @@ const ensureGgufModelFile = Effect.fn("ensureGgufModelFile")(function* (options:
 					new LlamaIntegrationHttpError({ operation: "download GGUF model (HTTPS)", cause }),
 			),
 		);
-	if (response.status < 200 || response.status >= 300) {
-		return yield* Effect.fail(
-			new LlamaIntegrationHttpError({
-				operation: `download GGUF model (HTTPS): unexpected HTTP status ${response.status} from ${modelUrlParsed.href}`,
-				cause: response,
-			}),
-		);
-	}
+	yield* failOnNonSuccessStatus({
+		response,
+		operation: "download GGUF model (HTTPS)",
+		requestUrl: modelUrlParsed,
+	});
 	const buf = yield* response.arrayBuffer.pipe(
 		Effect.map((ab) => new Uint8Array(ab)),
 		Effect.mapError(
@@ -354,14 +367,11 @@ const fetchFirstModelId = Effect.fn("fetchFirstModelId")(function* (openAiCompat
 				(cause) => new LlamaIntegrationHttpError({ operation: "request GET /v1/models", cause }),
 			),
 		);
-	if (response.status < 200 || response.status >= 300) {
-		return yield* Effect.fail(
-			new LlamaIntegrationHttpError({
-				operation: `request GET /v1/models: unexpected HTTP status ${response.status} from ${modelsUrl.href}`,
-				cause: response,
-			}),
-		);
-	}
+	yield* failOnNonSuccessStatus({
+		response,
+		operation: "request GET /v1/models",
+		requestUrl: modelsUrl,
+	});
 	const json: unknown = yield* response.json.pipe(
 		Effect.mapError(
 			(cause) =>

--- a/test/integration/llama-local-container.ts
+++ b/test/integration/llama-local-container.ts
@@ -312,12 +312,26 @@ const ensureGgufModelFile = Effect.fn("ensureGgufModelFile")(function* (options:
 			),
 		);
 	const http = yield* HttpClient.HttpClient;
-	const okClient = pipe(http, HttpClient.filterStatusOk);
-	const buf = yield* okClient.get(modelUrlParsed).pipe(
-		Effect.flatMap((response) => response.arrayBuffer),
+	const response = yield* http
+		.get(modelUrlParsed)
+		.pipe(
+			Effect.mapError(
+				(cause) =>
+					new LlamaIntegrationHttpError({ operation: "download GGUF model (HTTPS)", cause }),
+			),
+		);
+	if (response.status < 200 || response.status >= 300) {
+		return yield* Effect.fail(
+			new LlamaIntegrationHttpError({
+				operation: `download GGUF model (HTTPS): unexpected HTTP status ${response.status} from ${modelUrlParsed.href}`,
+				cause: response,
+			}),
+		);
+	}
+	const buf = yield* response.arrayBuffer.pipe(
 		Effect.map((ab) => new Uint8Array(ab)),
 		Effect.mapError(
-			(cause) => new LlamaIntegrationHttpError({ operation: "download GGUF model (HTTPS)", cause }),
+			(cause) => new LlamaIntegrationHttpError({ operation: "read GGUF response bytes", cause }),
 		),
 	);
 	yield* fs
@@ -333,9 +347,22 @@ const ensureGgufModelFile = Effect.fn("ensureGgufModelFile")(function* (options:
 const fetchFirstModelId = Effect.fn("fetchFirstModelId")(function* (openAiCompatBaseUrl: URL) {
 	const modelsUrl = openAiModelsListUrl(openAiCompatBaseUrl);
 	const http = yield* HttpClient.HttpClient;
-	const okClient = pipe(http, HttpClient.filterStatusOk);
-	const json: unknown = yield* okClient.get(modelsUrl).pipe(
-		Effect.flatMap((response) => response.json),
+	const response = yield* http
+		.get(modelsUrl)
+		.pipe(
+			Effect.mapError(
+				(cause) => new LlamaIntegrationHttpError({ operation: "request GET /v1/models", cause }),
+			),
+		);
+	if (response.status < 200 || response.status >= 300) {
+		return yield* Effect.fail(
+			new LlamaIntegrationHttpError({
+				operation: `request GET /v1/models: unexpected HTTP status ${response.status} from ${modelsUrl.href}`,
+				cause: response,
+			}),
+		);
+	}
+	const json: unknown = yield* response.json.pipe(
 		Effect.mapError(
 			(cause) =>
 				new LlamaIntegrationHttpError({ operation: "read JSON from GET /v1/models", cause }),


### PR DESCRIPTION
<!--
  Creating manually? Replace each placeholder below with your content.
  Using fill-pr-template? Run via auto-pr workflow or: npx -p github:knirski/auto-pr auto-pr-fill-pr-template --log-file <path> --files-file <path>
  See [docs/PR_TEMPLATE.md](https://github.com/knirski/auto-pr/blob/main/docs/PR_TEMPLATE.md)
-->

## Description

<!-- Narrative (auto-pr prefers ### Motivation, optional ### Benefits, ### Risks, and optional ### Notes for reviewers here). Commit subjects are under "Changes made" below. -->

### Motivation
- Multiple places in `test/integration/llama-local-container.ts` guarded against HTTP failures using similar but slightly different logic.
- HTTP failure diagnostics were not sufficiently clear, making debugging test failures harder.
- Streamlining the HTTP error handling improves test reliability and maintainability.

### Benefits
- Cleaner, more maintainable error handling in integration tests.
- Improved diagnostics make failing HTTP interactions easier to debug.

### Risks
- Review that deduplication does not alter test behavior for edge cases (e.g., non-2xx error responses).
- Ensure enhanced diagnostics do not leak sensitive information.
- Verify consistent handling for all HTTP failure scenarios covered previously.

### Notes for reviewers
Focus on HTTP error guards logic within `test/integration/llama-local-container.ts`. Compare pre/post to confirm all guards remain equivalent and diagnostics are improved.

## Type of change

<!-- Choose one: Bug fix | New feature | Breaking change | Documentation update | Chore -->

**Chore**. See [Conventional Commits](https://www.conventionalcommits.org/).

## Changes made

<!-- List specific changes. Omit for trivial PRs. -->

- refactor(integration): deduplicate non-2xx llama HTTP guard
- test(integration): improve llama HTTP failure diagnostics

## How to test

<!-- Step-by-step instructions for reviewers. Replace this block with project-specific commands (for example `npm run check` or `pytest`). For docs-only or trivial changes you can use "N/A" or delete the steps below. -->

1. Run the relevant tests or checks.
2. Add another step if needed.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have run `bun run check` and fixed any issues
- [ ] I have updated the documentation if needed
- [ ] I have added or updated tests for my changes

## Related issues

<!-- Use "Closes #123" to auto-close on merge. Leave blank if none. -->



## Breaking changes

<!-- Only if Type of change is "Breaking change". Leave blank otherwise. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for model downloads and API requests: failures now include operation context and requested URLs for easier diagnosis.
  * More robust network handling: request failures, non-success responses, and response-read errors are distinguished and reported more clearly.
  * No changes to public APIs or exported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->