### PR TITLE
docs(spec): clarify dynamic model limit and tier mapping

### DIFF
--- a/docs/superpowers/specs/2026-05-04-dynamic-github-model-usage-design.md
+++ b/docs/superpowers/specs/2026-05-04-dynamic-github-model-usage-design.md
@@ -17,7 +17,7 @@ Implemented today:
 - `src/core/model-routing.ts` classifies PR complexity into a model band, tool strategy, reasoning need, and static model id.
 - `src/workflow/auto-pr-build-model-routing-context.ts` writes `selected_model`, `tool_strategy`, and `routing_context` to `GITHUB_OUTPUT`.
 - `src/workflow/auto-pr-generate-content.ts` computes `toolRoundLimit` and `tokenBudget` from commit count, changed file count, and prompt size.
-- `src/core/sanitize-diff.ts` hard-caps AI tool response text at `8_000` chars, independent of selected model.
+- `src/core/sanitize-diff.ts` currently caps diff payloads with static limits (`MAX_PER_FILE_DIFF_CHARS = 10_000`, `MAX_TOTAL_DIFF_CHARS = 50_000`) and a separate static tool round-trip cap.
 
 This is deterministic, but it does not use live GitHub Models metadata or account limits.
 
@@ -112,7 +112,12 @@ export type GithubModelsPlanClass =
 	| "paid-usage"
 	| "unknown";
 
-export type GithubModelsRateLimitTier =
+export type GithubModelsCatalogRateLimitTier =
+	| "low"
+	| "high"
+	| "unknown";
+
+export type GithubModelsPolicyTier =
 	| "low"
 	| "high"
 	| "embedding"
@@ -132,7 +137,7 @@ export type GithubModelCatalogEntry = {
 	readonly supportedOutputModalities: readonly string[];
 	readonly maxInputTokens: number;
 	readonly maxOutputTokens: number;
-	readonly rateLimitTier: GithubModelsRateLimitTier;
+	readonly rateLimitTier: GithubModelsCatalogRateLimitTier;
 };
 
 export type GithubModelsRequestEnvelope = {
@@ -144,7 +149,7 @@ export type GithubModelsRequestEnvelope = {
 	readonly tokenBudget: number;
 	readonly toolRoundLimit: number;
 	readonly toolResponseCharBudget: number;
-	readonly rateLimitTier: GithubModelsRateLimitTier;
+	readonly rateLimitTier: GithubModelsPolicyTier;
 	readonly planClass: GithubModelsPlanClass;
 	readonly source: "catalog-and-plan" | "catalog-only" | "static-fallback" | "explicit-model";
 };
@@ -266,7 +271,7 @@ Final envelope:
 
 ### Dynamic Tool Response Payload
 
-Replace `MAX_AI_TOOL_ROUNDTRIP_DIFF_CHARS = 8_000` with an envelope-driven value.
+Replace static diff caps with envelope-driven values, including the tool round-trip cap.
 
 New behavior:
 
@@ -309,7 +314,7 @@ Keep old defaults for local and custom OpenAI-compatible providers.
 | Catalog fetch fails | Use current static model defaults and static conservative envelope. |
 | Catalog schema changes | Decode known fields, ignore extras, fallback on missing required fields. |
 | Org/user plan fetch forbidden | Use `unknown` plan class, treated as `copilot-free`. |
-| Explicit model not in catalog | Keep explicit model, apply conservative high-tier free limits. |
+| Explicit model not in catalog | Reject explicit model when catalog lookup succeeded; allow explicit model only when catalog lookup failed. |
 | Model lacks tool calling | If tools are required, select another model; if explicit model was set, disable tools and log warning. |
 | Request too large still occurs | Retry once with halved tool response budget and reduced tool strategy, then fall back to commit-derived PR content. |
 


### PR DESCRIPTION
<!--
  Creating manually? Replace each placeholder below with your content.
  Using fill-pr-template? Run via auto-pr workflow or: npx -p github:knirski/auto-pr auto-pr-fill-pr-template --log-file <path> --files-file <path>
  See [docs/PR_TEMPLATE.md](https://github.com/knirski/auto-pr/blob/main/docs/PR_TEMPLATE.md)
-->

## Description

<!-- Narrative (auto-pr prefers ### Motivation, optional ### Benefits, ### Risks, and optional ### Notes for reviewers here). Commit subjects are under "Changes made" below. -->

clarify dynamic model limit and tier mapping

## Type of change

<!-- Choose one: Bug fix | New feature | Breaking change | Documentation update | Chore -->

**Documentation update**. See [Conventional Commits](https://www.conventionalcommits.org/).

## Changes made

<!-- List specific changes. Omit for trivial PRs. -->

- docs(spec): clarify dynamic model limit and tier mapping

## How to test

<!-- Step-by-step instructions for reviewers. Replace this block with project-specific commands (for example `npm run check` or `pytest`). For docs-only or trivial changes you can use "N/A" or delete the steps below. -->

1. Run the relevant tests or checks.
2. Add another step if needed.

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I have run `bun run check` and fixed any issues
- [x] I have updated the documentation if needed
- [ ] I have added or updated tests for my changes

## Related issues

<!-- Use "Closes #123" to auto-close on merge. Leave blank if none. -->



## Breaking changes

<!-- Only if Type of change is "Breaking change". Leave blank otherwise. -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated design spec: replaces fixed truncation with envelope-driven, model/account-aware response char budgeting.
  - Adds catalog-based rate and policy tiers plus envelope metadata to carry policy info.
  - Diffing tools now enforce a computed per-tool response budget with a suggested hard ceiling of 32,000 chars.
  - Refined failure handling for explicit model selection when catalog lookup succeeds or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->